### PR TITLE
Add Telemetry log action to actions menu

### DIFF
--- a/content.js
+++ b/content.js
@@ -87,6 +87,12 @@
       name: "block",
       desc: "Disable autologin for this site"
     },
+    "TelemetryLog": {
+      file: "TelemetryLog.js",
+      icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 12L5 8l2.5 3L10 6l2 3 2-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><rect x="1" y="1" width="14" height="14" rx="2" stroke="currentColor" stroke-width="1.2"/></svg>`,
+      name: "telemetry",
+      desc: "Open Telemetry log (installs from Marketplace if not present)"
+    },
     "Settings": {
       file: null,
       icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="2"/><path d="M8 4v4l3 2" stroke="currentColor" stroke-width="2"/></svg>`,
@@ -627,7 +633,7 @@
       const lastUser = typeof rawEntry === "string" ? rawEntry : rawEntry?.username;
       const profile = data.userProfiles.find((p) => p.username === lastUser);
       const autologinEnabled = profile ? profile.autologin : false;
-      const actionsList = ["RestartApp", "FlushRedisDB"];
+      const actionsList = ["RestartApp", "FlushRedisDB", "TelemetryLog"];
       if (lastUser) actionsList.push(autologinEnabled ? "DisableAutologin" : "EnableAutologin");
       actionsList.forEach((name) => {
         const detail = ACTION_DETAILS[name];

--- a/scripts/actions/TelemetryLog.js
+++ b/scripts/actions/TelemetryLog.js
@@ -1,0 +1,74 @@
+(function () {
+    var MARKETPLACE_URL = 'https://marketplace.creatio.com/app/telemetry-log-creatio';
+    var base = window.location.protocol + '//' + window.location.host;
+    var REALOG_URL = base + '/0/Shell/#BaseSchemaModuleV2/Realog';
+
+    function getCsrf() {
+        var match = document.cookie.match(/(?:^|;\s*)BPMCSRF=([^;]*)/);
+        return match ? match[1] : '';
+    }
+
+    function showToast(text, color) {
+        var el = document.createElement('div');
+        el.textContent = text;
+        el.style.cssText = 'position:fixed;top:16px;left:50%;transform:translateX(-50%);' +
+            'background:' + color + ';color:#fff;padding:10px 20px;border-radius:4px;' +
+            'z-index:10000;box-shadow:0 2px 5px rgba(0,0,0,.3)';
+        document.body.appendChild(el);
+        setTimeout(function () { el.remove(); }, 4000);
+    }
+
+    var checkUrl = base + '/0/DataService/json/SyncReply/SelectQuery';
+    var requestBody = JSON.stringify({
+        rootSchemaName: 'SysPackage',
+        operationType: 0,
+        columns: {
+            items: {
+                Name: { expression: { expressionType: 0, columnPath: 'Name' } }
+            }
+        },
+        filters: {
+            logicalOperation: 0,
+            isEnabled: true,
+            filterType: 6,
+            items: {
+                NameFilter: {
+                    filterType: 1,
+                    comparisonType: 3,
+                    isEnabled: true,
+                    leftExpression: { expressionType: 0, columnPath: 'Name' },
+                    rightExpression: {
+                        expressionType: 2,
+                        parameter: { dataValueType: 1, value: 'Telemetry' }
+                    }
+                }
+            }
+        }
+    });
+
+    fetch(checkUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'BPMCSRF': getCsrf()
+        },
+        credentials: 'include',
+        body: requestBody
+    })
+    .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+    })
+    .then(function (data) {
+        var found = data && data.rows && data.rows.length > 0;
+        if (found) {
+            window.open(REALOG_URL, '_blank');
+        } else {
+            window.open(MARKETPLACE_URL, '_blank');
+        }
+    })
+    .catch(function () {
+        showToast('Could not check Telemetry package — check your connection', '#f44336');
+    });
+})();

--- a/src/menuBuilder.js
+++ b/src/menuBuilder.js
@@ -150,7 +150,7 @@ function buildActionsMenu(actionsMenuContainer) {
     const profile = data.userProfiles.find(p => p.username === lastUser);
     const autologinEnabled = profile ? profile.autologin : false;
 
-    const actionsList = ['RestartApp', 'FlushRedisDB'];
+    const actionsList = ['RestartApp', 'FlushRedisDB', 'TelemetryLog'];
     if (lastUser) actionsList.push(autologinEnabled ? 'DisableAutologin' : 'EnableAutologin');
 
     actionsList.forEach(name => {

--- a/src/menuConfig.js
+++ b/src/menuConfig.js
@@ -86,6 +86,12 @@ export const ACTION_DETAILS = {
     name: 'block',
     desc: 'Disable autologin for this site',
   },
+  'TelemetryLog': {
+    file: 'TelemetryLog.js',
+    icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 12L5 8l2.5 3L10 6l2 3 2-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><rect x="1" y="1" width="14" height="14" rx="2" stroke="currentColor" stroke-width="1.2"/></svg>`,
+    name: 'telemetry',
+    desc: 'Open Telemetry log (installs from Marketplace if not present)',
+  },
   'Settings': {
     file: null,
     icon: `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="2"/><path d="M8 4v4l3 2" stroke="currentColor" stroke-width="2"/></svg>`,


### PR DESCRIPTION
## Summary
- Adds a **Telemetry log** item to the lightning bolt actions menu
- On click, queries the Creatio DataService (`/0/DataService/json/SyncReply/SelectQuery`) to check if the `Telemetry` package is installed
- If installed → opens `{baseUrl}/0/Shell/#BaseSchemaModuleV2/Realog` in a new tab
- If not installed → redirects to the [Marketplace listing](https://marketplace.creatio.com/app/telemetry-log-creatio)
- Base URL is derived dynamically from `window.location` — no hardcoded hosts

## Test plan
- [ ] Build extension (`npm run build`) and load unpacked in Chrome
- [ ] Open a Creatio shell page — confirm **Telemetry log** appears in the ⚡ actions menu
- [ ] With Telemetry package absent: clicking opens the Marketplace URL
- [ ] With Telemetry package present: clicking opens the Realog page on the correct host

🤖 Generated with [Claude Code](https://claude.com/claude-code)